### PR TITLE
feat: default API path

### DIFF
--- a/client/src/AuthContext.js
+++ b/client/src/AuthContext.js
@@ -8,7 +8,7 @@ export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
 
   // Base URL de la API desde variable de entorno
-  const API = process.env.REACT_APP_API_URL;
+  const API = process.env.REACT_APP_API_URL || '';
   // Ejemplo: "https://backend-d7qm.onrender.com"
 
   // Cargar usuario al iniciar

--- a/client/src/components/Checkout.jsx
+++ b/client/src/components/Checkout.jsx
@@ -13,7 +13,7 @@ export default function Checkout() {
   const [message, setMessage] = useState(null);
 
   // Base URL de la API desde variable de entorno
-  const API = process.env.REACT_APP_API_URL; 
+  const API = process.env.REACT_APP_API_URL || '';
   // Ejemplo: "https://backend-d7qm.onrender.com"
 
   useEffect(() => {

--- a/client/src/components/Login.jsx
+++ b/client/src/components/Login.jsx
@@ -12,7 +12,7 @@ export default function LoginModal() {
   const [error, setError] = useState('');
 
   // Base URL de la API desde variable de entorno
-  const API = process.env.REACT_APP_API_URL;
+  const API = process.env.REACT_APP_API_URL || '';
 
   const handle = e => {
     setForm(f => ({ ...f, [e.target.name]: e.target.value }));

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -13,7 +13,7 @@ export default function NavBar() {
   const [isTransparent, setTransparent] = useState(false);
 
   // Base URL de la API desde variable de entorno
-  const API = process.env.REACT_APP_API_URL; 
+  const API = process.env.REACT_APP_API_URL || '';
   // Ejemplo: "https://backend-d7qm.onrender.com"
 
   // Verificar si estamos en la página de productos

--- a/client/src/components/ProductDetail.jsx
+++ b/client/src/components/ProductDetail.jsx
@@ -15,7 +15,7 @@ export default function ProductDetail() {
   const [maxPrice, setMaxPrice] = useState(Infinity);
 
   // Base URL de la API desde variable de entorno
-  const API = process.env.REACT_APP_API_URL; 
+  const API = process.env.REACT_APP_API_URL || '';
   // Ejemplo: "https://backend-d7qm.onrender.com"
 
   useEffect(() => {

--- a/client/src/components/ProductList.jsx
+++ b/client/src/components/ProductList.jsx
@@ -20,7 +20,7 @@ export default function ProductList() {
   const navigate = useNavigate();
 
   // Lee la URL base de tu API desde la variable de entorno
-  const API = process.env.REACT_APP_API_URL; 
+  const API = process.env.REACT_APP_API_URL || '';
   // Por ejemplo: "https://backend-d7qm.onrender.com"
 
   useEffect(() => {

--- a/client/src/components/Register.jsx
+++ b/client/src/components/Register.jsx
@@ -14,7 +14,7 @@ export default function RegisterModal() {
     
 
   // Base URL de la API desde variable de entorno
-  const API = process.env.REACT_APP_API_URL;
+  const API = process.env.REACT_APP_API_URL || '';
 
   const handle = e => {
     setForm(f => ({ ...f, [e.target.name]: e.target.value }));


### PR DESCRIPTION
## Summary
- use fallback API base URL across client components so cart and auth work even without REACT_APP_API_URL

## Testing
- `npm test` *(server: no tests specified)*
- `CI=true npm test --prefix client -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_b_6893afbb375083209531c5245ccdc490